### PR TITLE
fixed ImportError on Python 3.4

### DIFF
--- a/vapory/__init__.py
+++ b/vapory/__init__.py
@@ -1,7 +1,7 @@
 """ vapory/__init__.py """
 
 
-from vapory import *
+from .vapory import *
 from .version import __version__
 
  


### PR DESCRIPTION
This fixes a basic ImportError that arises on Python 3.4.

Here's the problem:
- Running `python setup.py install --user` runs just fine, and copies everything important.
- Running `>>> import vapory; dir(vapory)` shows that nothing is in that folder.
- The reason is that the `import vapory` line in `__init__.py` just imports the whole module - it doesn't know to import the `vapory/vapory.py` _submodule_. This is a change in import behavior in Python 3.

Using the `from .vapory import *` (with the period!) enforces the "import the submodule behavior" that is intended.

After testing, I can confirm that this seems to work fine on Python 2.7 as well.
