### PR TITLE
fixed encoding issue

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -105,7 +105,7 @@ def render_povstring(string, outfile=None, height=None, width=None,
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE)
 
-    out, err = process.communicate(string)
+    out, err = process.communicate(string.encode('ascii'))
     
     if remove_temp:
         os.remove(pov_file)


### PR DESCRIPTION
This fixes Issue #1.

On my machine, `python examples/cube.py` and `python2 examples/cube.py` both complete successfully (and make `cube.png`). That's Python version 2.7 and 3.4.
