### PR TITLE
Add the ability to hide the render window.

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -54,7 +54,7 @@ def ppm_to_numpy(filename=None, buffer=None, byteorder='>'):
 
 def render_povstring(string, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     show_window=True):
+                     show_window=False):
     
     """ Renders the provided scene description with POV-Ray.
     

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -74,7 +74,7 @@ class Scene:
 
     def render(self, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     auto_camera_angle=True, show_window=True):
+                     auto_camera_angle=True, show_window=False):
     
         """ Renders the scene to a PNG, a numpy array, or the IPython Notebook.
 


### PR DESCRIPTION
This adds the `show_window` flag to `Scene.render`, which allows the caller to show or hide the render window as desired.
