### PR TITLE
Fixed two minor errors

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -115,7 +115,8 @@ def render_povstring(string, outfile=None, height=None, width=None,
         os.remove(pov_file)
 
     if process.returncode:
-        raise IOError("POVRay rendering failed with the following error: "+err)
+        print(type(err), err)
+        raise IOError("POVRay rendering failed with the following error: "+err.decode('ascii'))
 
     if return_np_array:
         return ppm_to_numpy(buffer=out)

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import re
 from .io import render_povstring
 
-from helpers import WIKIREF, vectorize, format_if_necessary
+from .helpers import WIKIREF, vectorize, format_if_necessary
 
 class Scene:
     """ A scene contains Items and can be written to a file.


### PR DESCRIPTION
This fixes two errors that pop up in Python 3.

The first (in `vapory.py`) is a simple relative import error; the second is a decoding error that only pops up when povray is given invalid input.
