### PR TITLE
Can pass in path of temporary .pov file to render.

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -54,7 +54,7 @@ def ppm_to_numpy(filename=None, buffer=None, byteorder='>'):
 
 def render_povstring(string, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     show_window=False):
+                     show_window=False, tempfile=None):
 
     """ Renders the provided scene description with POV-Ray.
 
@@ -79,7 +79,7 @@ def render_povstring(string, outfile=None, height=None, width=None,
 
     """
 
-    pov_file = '__temp__.pov'
+    pov_file = tempfile or '__temp__.pov'
     with open(pov_file, 'w+') as f:
         f.write(string)
 

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -54,7 +54,7 @@ class Scene:
 
     def render(self, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     auto_camera_angle=True, show_window=False):
+                     auto_camera_angle=True, show_window=False, tempfile=None):
 
         """ Renders the scene to a PNG, a numpy array, or the IPython Notebook.
 
@@ -79,7 +79,7 @@ class Scene:
             self.camera = self.camera.add_args(['right', [1.0*width/height, 0,0]])
 
         return render_povstring(str(self), outfile, height, width,
-                                quality, antialiasing, remove_temp, show_window)
+                                quality, antialiasing, remove_temp, show_window, tempfile)
 
 
 class POVRayElement:


### PR DESCRIPTION
Hi, thanks for this library.

I'm running Vapory in a server environment and my Python process does not have write access to its current working directory, so creating `__temp__.pov` will always fail: https://github.com/Zulko/vapory/blob/master/vapory/io.py#L82

Ideally the default behavior would be to use the `tempfile` module but it seems like this would break how the `remove_temp` option works. So this PR is maybe an uglier way to fix it?

I'm using it like this


    import tempfile
    ...
    t = tempfile.NamedTemporaryFile(delete=False,suffix=".pov")
    scene.render("cube.png", width=300, height=300, antialiasing=0.001, tempfile=t.name)