### PR TITLE
updated vapory for python under windows and made a bugfix for 16 bit images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ nosetests.xml
 # Pipy codes
 
 .pypirc
+
+# povray output
+*.pov
+*.ppm
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ nosetests.xml
 *.pov
 *.ppm
 *.png
+
+Thumbs.db

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -11,4 +11,9 @@ scene = Scene(
                 Sphere( [0, 1, 2] , 2,   Texture( Pigment( 'color', [1,0,1])))]
 )
 
-scene.render("sphere.png", width = 600, height=400, remove_temp=0)
+print(("start rendering"))
+
+scene.render("sphere1.png", width = 600, height=400, remove_temp=0)
+print(("done."))
+
+scene.render("sphere2.png", width =1200, height=800, remove_temp=0)

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1,6 +1,8 @@
 """ Just a purple sphere """
 
 from vapory import *
+import matplotlib.pyplot as plt
+
 
 scene = Scene(
 
@@ -11,9 +13,7 @@ scene = Scene(
                 Sphere( [0, 1, 2] , 2,   Texture( Pigment( 'color', [1,0,1])))]
 )
 
-print(("start rendering"))
 
-scene.render("sphere1.png", width = 600, height=400, remove_temp=0)
-print(("done."))
+nparray=scene.render(width = 600, height=400, remove_temp=1)
 
-scene.render("sphere2.png", width =1200, height=800, remove_temp=0)
+plt.imshow(nparray)

--- a/vapory/config.py
+++ b/vapory/config.py
@@ -1,6 +1,6 @@
 import os
 
-POVRAY_BINARY = ("povray.exe" if os.name=='nt' else "povray")
+POVRAY_BINARY = ("pvengine64.exe" if os.name=='nt' else "povray")
 
 GLOBAL_SCENE_SETTINGS = {
     "charset"        : "ascii",

--- a/vapory/io.py
+++ b/vapory/io.py
@@ -54,7 +54,7 @@ def ppm_to_numpy(filename=None, buffer=None, byteorder='>'):
 
 def render_povstring(string, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     show_window=False, tempfile=None):
+                     show_window=False, tempfile=None,exit_when_done=True):
 
     """ Renders the provided scene description with POV-Ray.
 
@@ -99,7 +99,8 @@ def render_povstring(string, outfile=None, height=None, width=None,
 
     cmd = [POVRAY_BINARY]
     if os.name=='nt':
-        cmd.append('/EXIT')
+        if exit_when_done:
+            cmd.append('/EXIT')
         cmd.append('/RENDER')
     cmd.append(pov_file)
     if height is not None: cmd.append('+H%d'%height)
@@ -118,6 +119,7 @@ def render_povstring(string, outfile=None, height=None, width=None,
                                    stdout=subprocess.PIPE)
 
     out, err = process.communicate(string.encode('ascii'))
+
     
     if remove_temp:
         os.remove(pov_file)

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -52,7 +52,7 @@ class Scene:
         new.objects +=  objs
         return new
 
-    def render(self, outfile=None, height=None, width=None,
+    def render(self, outfile=None, height=None, width=None,bitspercolor=None,
                      quality=None, antialiasing=None, remove_temp=True,
                      auto_camera_angle=True, show_window=False, tempfile=None,
                      exit_when_done=True):
@@ -79,7 +79,7 @@ class Scene:
         if auto_camera_angle and width is not None:
             self.camera = self.camera.add_args(['right', [1.0*width/height, 0,0]])
 
-        return render_povstring(str(self), outfile, height, width,
+        return render_povstring(str(self), outfile, height, width,bitspercolor,
                                 quality, antialiasing, remove_temp, show_window, tempfile,
                                 exit_when_done)
 

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -54,7 +54,8 @@ class Scene:
 
     def render(self, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     auto_camera_angle=True, show_window=False, tempfile=None):
+                     auto_camera_angle=True, show_window=False, tempfile=None,
+                     exit_when_done=True):
 
         """ Renders the scene to a PNG, a numpy array, or the IPython Notebook.
 
@@ -79,7 +80,8 @@ class Scene:
             self.camera = self.camera.add_args(['right', [1.0*width/height, 0,0]])
 
         return render_povstring(str(self), outfile, height, width,
-                                quality, antialiasing, remove_temp, show_window, tempfile)
+                                quality, antialiasing, remove_temp, show_window, tempfile,
+                                exit_when_done)
 
 
 class POVRayElement:


### PR DESCRIPTION
Hi Zulko,
First of all, many thanks for this python api for pov-ray, it is exactly what I was looking for!
I installed it last week and started working with it. I am working with python3 under windows and fixed some errors which were related to differences between python under linux and windows. In the windows version, piping is not allowed so in order to return the image inmediately to a numpy array you have to a temporary write it to file. So I have added that. Also the name of the povray executatble is different (not povray, but pvengine64.exe). Finally I added a bug fix for 16 bit images. In order to set the byte order, it should be >u2 en not >uint16. this later may be a typical python3 change so you may want to check that. Anyway, in case you are interested to merge my changes, please go ahead. 
Regards
