### PR TITLE
Added option to enable alpha channel of POV-Ray output

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -78,6 +78,13 @@ def render_povstring(string, outfile=None, height=None, width=None,
     width
       width in pixels
 
+    output_alpha
+      If true, the background will be transparent,
+    rather than the default black background.  Note
+    that this option is ignored if rendering to a
+    numpy array, due to limitations of the intermediate
+    ppm format.
+
     """
 
     pov_file = tempfile or '__temp__.pov'

--- a/vapory/io.py
+++ b/vapory/io.py
@@ -54,7 +54,8 @@ def ppm_to_numpy(filename=None, buffer=None, byteorder='>'):
 
 def render_povstring(string, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
-                     show_window=False, tempfile=None, includedirs=None):
+                     show_window=False, tempfile=None, includedirs=None,
+                     output_alpha=False):
 
     """ Renders the provided scene description with POV-Ray.
 
@@ -99,6 +100,7 @@ def render_povstring(string, outfile=None, height=None, width=None,
     if width is not None: cmd.append('+W%d'%width)
     if quality is not None: cmd.append('+Q%d'%quality)
     if antialiasing is not None: cmd.append('+A%f'%antialiasing)
+    if output_alpha: cmd.append('Output_Alpha=on')
     if not show_window:
         cmd.append('-D')
     else:

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -77,6 +77,13 @@ class Scene:
         width
           width in pixels
 
+        output_alpha
+          If true, the background will be transparent,
+        rather than the default black background.  Note
+        that this option is ignored if rendering to a
+        numpy array, due to limitations of the intermediate
+        ppm format.
+
         """
 
         if auto_camera_angle and width is not None:

--- a/vapory/vapory.py
+++ b/vapory/vapory.py
@@ -58,7 +58,7 @@ class Scene:
     def render(self, outfile=None, height=None, width=None,
                      quality=None, antialiasing=None, remove_temp=True,
                      auto_camera_angle=True, show_window=False, tempfile=None,
-                     includedirs=None):
+                     includedirs=None, output_alpha=False):
 
         """ Renders the scene to a PNG, a numpy array, or the IPython Notebook.
 
@@ -84,7 +84,7 @@ class Scene:
 
         return render_povstring(str(self), outfile, height, width,
                                 quality, antialiasing, remove_temp, show_window,
-                                tempfile, includedirs)
+                                tempfile, includedirs, output_alpha)
 
 
 class POVRayElement:


### PR DESCRIPTION
Allows for the "Output_Alpha=on" to be passed.  As implemented, it only affects an output image that is saved directly in the `render()` method.  As the ppm data output from pov-ray does not contain the alpha channel, having the alpha channel present in a returned numpy array would require saving to a temporary file, which was a larger change than I wanted to make.