### PR TITLE
Removed "IOError" from exception which was preventing exception from

### DIFF
--- a/vapory/io.py
+++ b/vapory/io.py
@@ -10,7 +10,7 @@ from .config import POVRAY_BINARY
 try:
     import numpy
     numpy_found=True
-except IOError:
+except:
     numpy_found=False
 
 try:


### PR DESCRIPTION
being raised, confusing users. (failing to import does not raise an
IOError, it raises an import error)